### PR TITLE
Extract Integer and Float extensions to core_ext.rb

### DIFF
--- a/lib/inspectable_numbers.rb
+++ b/lib/inspectable_numbers.rb
@@ -12,15 +12,4 @@ module InspectableNumbers
   end
 end
 
-class Integer
-  def inspect(base=10)
-    base == 10 ? InspectableNumbers.underscore_number(self) : 
-                 to_s(base)
-  end
-end
-
-class Float
-  def inspect
-    InspectableNumbers.underscore_number(self)
-  end
-end
+require "inspectable_numbers/core_ext"

--- a/lib/inspectable_numbers/core_ext.rb
+++ b/lib/inspectable_numbers/core_ext.rb
@@ -1,0 +1,12 @@
+class Integer
+  def inspect(base=10)
+    base == 10 ? InspectableNumbers.underscore_number(self) :
+                 to_s(base)
+  end
+end
+
+class Float
+  def inspect
+    InspectableNumbers.underscore_number(self)
+  end
+end


### PR DESCRIPTION
A common ruby convention is to keep any freedom patches in either a `core_ext.rb` file or a `core_ext` directory. Here's a reference to this rule in the rails guides, but I'm pretty sure there's non-rails examples out there, too: https://guides.rubyonrails.org/plugins.html#extending-core-classes. Active support also goes to great lengths to allow cherry-picking: https://guides.rubyonrails.org/active_support_core_extensions.html#stand-alone-active-support

This has documentation value, both if you're looking around the codebase, and if you're looking at a backtrace -- seeing `core_ext` in an error line is going to tell you to expect some core class being changed. Ideally, it would also be possible to require the logic without requiring the core extension, but for that, you'd need to pull out the `underscore_number` method into its own file, and I couldn't think of how to name it.